### PR TITLE
Update dobre-praktyki.md text vs example consistency improvement

### DIFF
--- a/dobre-praktyki.md
+++ b/dobre-praktyki.md
@@ -173,7 +173,7 @@ Zasada jest taka: Jeżeli masz plik example.cpp i inludujesz jego header #includ
 
 ```cpp
 // Here is place for header
-#include "example.h"
+#include "example.hpp"
 
 // Here is place for standard library
 #include <algorithm>


### PR DESCRIPTION
In the text is mentioned "example.hpp" but in example "example.h"